### PR TITLE
API Access Key availability

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,23 @@ whmcs-ruby provides Ruby bindings for the [WHMCS API](http://wiki.whmcs.com/API:
 
     WHMCS::Client.get_clients_details(:clientid => '1')
 
+## API Access Key
+
+Recently, WHMCS offered [another type](http://docs.whmcs.com/API:Access_Keys) of authenticating API requests.
+Using API Access Key might be useful for mobile devices and/or IPv6 bug WHMCS whitelists currently have.
+
+	require 'whmcs'
+
+    WHMCS.configure do |config|
+      config.api_url      = 'http://example.com/includes/api.php'
+      config.api_username = 'someusername'
+      config.api_password = 'c4ca4238a0b923820dcc509a6f75849b' # md5 hash
+	  config.api_access_key = 'YetAnotherAPIAccessKeyForWHMCS'
+    end
+
+    WHMCS::Client.get_clients_details(:clientid => '1')
+
+
 See the [documentation](http://dotblock.github.com/whmcs-ruby/) for more
 details.
 

--- a/lib/whmcs/base.rb
+++ b/lib/whmcs/base.rb
@@ -22,6 +22,11 @@ module WHMCS
         :password => WHMCS.config.api_password
       )
 
+	  # alternative API access
+	  if( !WHMCS.config.api_access_key.nil? )
+		  params.merge!( :accesskey => WHMCS.config.api_access_key )
+	  end
+
       url = URI.parse(WHMCS.config.api_url)
 
       http = Net::HTTP.new(url.host, url.port)

--- a/lib/whmcs/config.rb
+++ b/lib/whmcs/config.rb
@@ -10,11 +10,15 @@ module WHMCS
     # The WHMCS API URL
     attr_accessor :api_url
 
+	# The WHMCS API Access Key
+	attr_accessor :api_access_key
+
     # Create a new config object
     def initialize
       @api_username = 'example_api_user'
       @api_password = 'example_api_pass'
       @api_url      = 'http://example.com/api.php'
+	  @api_access_key = '3x4mpL3_k3y'
     end
   end
 end

--- a/lib/whmcs/version.rb
+++ b/lib/whmcs/version.rb
@@ -1,3 +1,3 @@
 module WHMCS #:nodoc:
-  VERSION = Version = '0.0.1'
+  VERSION = Version = '0.0.2'
 end


### PR DESCRIPTION
[API Access Key](http://docs.whmcs.com/API:Access_Keys) allows to avoid issues with dynamic IP's. Also it helps to avoid [IPv6 bug](http://anvyst.com/2013/11/whmcs-ipv6-issues/) in API IP lists.
